### PR TITLE
Keep Ping application alive without WebFlux

### DIFF
--- a/ping/pom.xml
+++ b/ping/pom.xml
@@ -19,15 +19,17 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webflux</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-rsocket</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-gateway-rsocket-client</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-configuration-processor</artifactId>
+			<optional>true</optional>
 		</dependency>
 	</dependencies>
 

--- a/ping/src/main/java/org/springframework/cloud/rsocket/sample/ping/PingApplication.java
+++ b/ping/src/main/java/org/springframework/cloud/rsocket/sample/ping/PingApplication.java
@@ -1,90 +1,16 @@
 package org.springframework.cloud.rsocket.sample.ping;
 
-import java.time.Duration;
-import java.util.concurrent.atomic.AtomicInteger;
-
-import lombok.extern.slf4j.Slf4j;
-import reactor.core.publisher.Flux;
-
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.event.ApplicationReadyEvent;
-import org.springframework.cloud.gateway.rsocket.client.BrokerClient;
-import org.springframework.context.ApplicationListener;
-import org.springframework.context.annotation.Bean;
-import org.springframework.core.env.ConfigurableEnvironment;
-import org.springframework.messaging.rsocket.RSocketRequester;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @SpringBootApplication
+@EnableConfigurationProperties(PingProperties.class)
 public class PingApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(PingApplication.class, args);
 	}
 
-	@Bean
-	public Ping ping(BrokerClient brokerClient) {
-		return new Ping(brokerClient);
-	}
-
-	@Slf4j
-	public static class Ping implements ApplicationListener<ApplicationReadyEvent> {
-
-		private final BrokerClient client;
-
-		private final AtomicInteger pongsReceived = new AtomicInteger();
-
-		public Ping(BrokerClient client) {
-			this.client = client;
-		}
-
-		@Override
-		public void onApplicationEvent(ApplicationReadyEvent event) {
-			ConfigurableEnvironment env = event.getApplicationContext().getEnvironment();
-
-			String requestType = env.getProperty("ping.request-type", "request-channel");
-			log.info("Starting Ping" + client.getProperties().getRouteId() + " request type: " + requestType);
-
-			RSocketRequester requester = client.connect().block();
-
-			if (requestType.equals("actuator")) {
-				requester.route("hello")
-						.metadata(client.forwarding(fwd -> fwd.serviceName("gateway")
-								.disableProxy()))
-						.data("ping")
-						.retrieveMono(String.class)
-						.subscribe(s -> log.info("received from actuator: " + s));
-			}
-			else if (requestType.equals("request-response")) {
-				Flux.interval(Duration.ofSeconds(1))
-						.flatMap(i -> requester.route("pong-rr")
-								.metadata(client.forwarding("pong"))
-								.data("ping" + i)
-								.retrieveMono(String.class)
-								.doOnNext(this::logPongs))
-						.subscribe();
-
-			}
-			else {
-				requester.route("pong-rc")
-						.metadata(client.forwarding("pong"))
-						.data(Flux.interval(Duration.ofSeconds(1)).map(this::getPayload)
-								.onBackpressureDrop(payload -> log
-										.info("Backpressure applied, dropping payload " + payload)))
-						.retrieveFlux(String.class)
-						.subscribe(this::logPongs);
-			}
-
-		}
-
-		private String getPayload(long i) {
-			return "ping" + i;
-		}
-
-		private void logPongs(String payload) {
-			int received = pongsReceived.incrementAndGet();
-			log.info("received " + payload + "(" + received + ") in Ping" + client.getProperties().getRouteId());
-		}
-	}
 }
 

--- a/ping/src/main/java/org/springframework/cloud/rsocket/sample/ping/PingProperties.java
+++ b/ping/src/main/java/org/springframework/cloud/rsocket/sample/ping/PingProperties.java
@@ -1,0 +1,23 @@
+package org.springframework.cloud.rsocket.sample.ping;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("ping")
+public class PingProperties {
+
+	private RequestType requestType = RequestType.REQUEST_CHANNEL;
+
+	public RequestType getRequestType() {
+		return requestType;
+	}
+
+	public void setRequestType(RequestType requestType) {
+		this.requestType = requestType;
+	}
+
+	static enum RequestType {
+		REQUEST_CHANNEL,
+		REQUEST_RESPONSE,
+		ACTUATOR
+	}
+}

--- a/ping/src/main/java/org/springframework/cloud/rsocket/sample/ping/PingService.java
+++ b/ping/src/main/java/org/springframework/cloud/rsocket/sample/ping/PingService.java
@@ -1,0 +1,80 @@
+package org.springframework.cloud.rsocket.sample.ping;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import reactor.core.publisher.Flux;
+
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.cloud.gateway.rsocket.client.BrokerClient;
+import org.springframework.context.ApplicationListener;
+import org.springframework.messaging.rsocket.RSocketRequester;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PingService implements ApplicationListener<ApplicationReadyEvent> {
+
+	private static final Logger logger = LoggerFactory.getLogger(PingService.class);
+
+	private final BrokerClient client;
+
+	private final PingProperties properties;
+
+	private final AtomicInteger pongsReceived = new AtomicInteger();
+
+	public PingService(BrokerClient client, PingProperties properties) {
+		this.client = client;
+		this.properties = properties;
+	}
+
+
+	@Override
+	public void onApplicationEvent(ApplicationReadyEvent event) {
+		logger.info("Starting Ping" + client.getProperties().getRouteId() + " request type: " + properties.getRequestType());
+		RSocketRequester requester = client.connect().retry(5).block();
+
+		switch (properties.getRequestType()) {
+			case REQUEST_RESPONSE:
+				Flux.interval(Duration.ofSeconds(1))
+						.flatMap(i -> requester.route("pong-rr")
+								.metadata(client.forwarding("pong"))
+								.data("ping" + i)
+								.retrieveMono(String.class)
+								.doOnNext(this::logPongs))
+						.then().block();
+				break;
+
+			case REQUEST_CHANNEL:
+				requester.route("pong-rc")
+						.metadata(client.forwarding("pong"))
+						.data(Flux.interval(Duration.ofSeconds(1)).map(this::getPayload)
+								.onBackpressureDrop(payload -> logger
+										.info("Backpressure applied, dropping payload " + payload)))
+						.retrieveFlux(String.class)
+						.doOnNext(this::logPongs)
+						.then().block();
+				break;
+
+			case ACTUATOR:
+				requester.route("hello")
+						.metadata(client.forwarding(fwd -> fwd.serviceName("gateway")
+								.disableProxy()))
+						.data("ping")
+						.retrieveMono(String.class)
+						.doOnNext(s -> logger.info("received from actuator: " + s))
+						.then().block();
+				break;
+		}
+	}
+
+	private String getPayload(long i) {
+		return "ping" + i;
+	}
+
+	private void logPongs(String payload) {
+		int received = pongsReceived.incrementAndGet();
+		logger.info("received " + payload + "(" + received + ") in Ping" + client.getProperties().getRouteId());
+	}
+}

--- a/ping/src/main/resources/application.yml
+++ b/ping/src/main/resources/application.yml
@@ -21,4 +21,4 @@ spring.cloud.gateway.rsocket.client:
     INSTANCE_NAME: ping2
 
 ping:
-  request-type: request-response
+  request-type: request_response

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,6 @@
 
 	<properties>
 		<java.version>1.8</java.version>
-		<!-- Remove when boot updates -->
-		<rsocket.version>1.0.0-RC3-SNAPSHOT</rsocket.version>
 		<spring-cloud.version>Hoxton.BUILD-SNAPSHOT</spring-cloud.version>
 	</properties>
 


### PR DESCRIPTION
Prior to this commit, the Ping application would have a dependency on
the WebFlux starter to start a server and artificially keep the
application up, even if it doesn't need a server.

Spring Boot applications, in general, are kept up until all
command-line/application runners are done and all non-daemon threads are
stopped.

In this case, if we remove the webflux starter the application has no
non-daemon thread (i.e. no server) and the runners and in this case the
event listener are done quite quickly since the reactive pipelines are
terminated with the `subscribe` operator.
The `subscribe` operator kicks off the processing of the pipeline and
schedules that work on the reactor infrastructure - but nothing waits
for the completion of this work.

This commit adds `.then().block()` operators at the end of those
pipelines to make sure that the application remains up until processing
is done.

Note that the Spring Framework team is currently investigating whether
we can improve the publishing and handling of application events in
reactive applications.